### PR TITLE
Add feature for merging config files

### DIFF
--- a/pydeepmerge/__init__.py
+++ b/pydeepmerge/__init__.py
@@ -13,3 +13,5 @@ from pydeepmerge._deep_merge import deep_merge  # noqa: F401
 # in the _deep_merge module it'll cause a circular
 # import
 strategies.prefer_right = _deep_merge.prefer_right
+
+from pydeepmerge._merge_configs import merge_configs  # noqa: F401, E402

--- a/pydeepmerge/_deep_merge.py
+++ b/pydeepmerge/_deep_merge.py
@@ -1,14 +1,16 @@
 from collections.abc import Mapping
 from pydeepmerge.types import Key
-from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List
+)
 import logging
 
 MergeStrategy = Callable[[Any, Any], Any]
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
 
 def prefer_right(left_value: Any, right_value: Any) -> Any:

--- a/pydeepmerge/_deep_merge.py
+++ b/pydeepmerge/_deep_merge.py
@@ -10,7 +10,7 @@ import logging
 
 MergeStrategy = Callable[[Any, Any], Any]
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 
 def prefer_right(left_value: Any, right_value: Any) -> Any:

--- a/pydeepmerge/_merge_configs.py
+++ b/pydeepmerge/_merge_configs.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+from pydeepmerge import deep_merge
+from pydeepmerge.errors import (
+    FileTypeError,
+    ParserNotAvailableError
+)
+from pydeepmerge.parsers import load_parsers
+from pydeepmerge.strategies import prefer_right
+from pydeepmerge.types import MergeStrategy
+from typing import (
+    Dict,
+    List,
+)
+
+
+def merge_configs(
+    *files: List[str],
+    merge_strategy: MergeStrategy = prefer_right,
+    auto: bool = True,
+    strict: bool = True,
+    extra_parsers: Dict = {}
+) -> Dict:
+    '''
+    A function that takes a sequence of config filenames and produces
+    a dictionary resulting from all the files being processed and then merged
+    with a specified merge strategy.
+
+    To use custom parsers, pass a flat dictionary of filetypes and parsers.
+    If `auto` is set to False, use only the parsers explicitly passed
+    through the `extra_parsers` parameter.
+
+    If `strict` is set to True, all file names must have the same extension.
+    This also applies to file type variations like `.yml` vs `.yaml`
+    '''
+    parsers = {}
+
+    if strict:
+        file_iter = iter(files)
+        first_file_name = next(file_iter)
+
+        file_type = Path(first_file_name).suffix
+
+        if file_type == '':
+            raise FileTypeError(
+                f'File "{first_file_name}" has no file type extension'
+            )
+
+        for file_name in file_iter:
+            if Path(file_name).suffix != file_type:
+                raise FileTypeError(
+                    f'File "{file_name}" has improper filetype. '
+                    f'Expected file type of "{file_type}"'
+                )
+
+    if auto:
+        parsers = load_parsers()
+
+    parsers.update(extra_parsers)
+
+    file_data = []
+
+    for file_name in files:
+        file_type = Path(file_name).suffix
+
+        if file_type not in parsers:
+            raise ParserNotAvailableError(f'No parser for "{file_type}"')
+
+        parser = parsers[file_type]
+        file_data.append(parser(file_name))
+
+    return deep_merge(*file_data, merge_strategy=merge_strategy)

--- a/pydeepmerge/_merge_configs.py
+++ b/pydeepmerge/_merge_configs.py
@@ -43,14 +43,14 @@ def merge_configs(
 
         if file_type == '':
             raise FileTypeError(
-                f'File "{first_file_name}" has no file type extension'
+                'File "%s" has no file type extension' % first_file_name
             )
 
         for file_name in file_iter:
             if Path(file_name).suffix != file_type:
                 raise FileTypeError(
-                    f'File "{file_name}" has improper filetype. '
-                    f'Expected file type of "{file_type}"'
+                    'File "%s" has improper filetype. '
+                    'Expected file type of "%s"' % (file_name, file_type)
                 )
 
     if auto:

--- a/pydeepmerge/_merge_configs.py
+++ b/pydeepmerge/_merge_configs.py
@@ -33,7 +33,6 @@ def merge_configs(
     If `strict` is set to True, all file names must have the same extension.
     This also applies to file type variations like `.yml` vs `.yaml`
     '''
-    parsers = {}
 
     if strict:
         file_iter = iter(files)
@@ -53,6 +52,7 @@ def merge_configs(
                     'Expected file type of "%s"' % (file_name, file_type)
                 )
 
+    parsers = {}
     if auto:
         parsers = load_parsers()
 

--- a/pydeepmerge/_merge_configs.py
+++ b/pydeepmerge/_merge_configs.py
@@ -64,7 +64,7 @@ def merge_configs(
         file_type = Path(file_name).suffix
 
         if file_type not in parsers:
-            raise ParserNotAvailableError(f'No parser for "{file_type}"')
+            raise ParserNotAvailableError('No parser for "%s"' % file_type)
 
         parser = parsers[file_type]
         file_data.append(parser(file_name))

--- a/pydeepmerge/errors/__init__.py
+++ b/pydeepmerge/errors/__init__.py
@@ -1,0 +1,4 @@
+from pydeepmerge.errors.errors import (  # noqa: F401
+    FileTypeError,
+    ParserNotAvailableError,
+)

--- a/pydeepmerge/errors/errors.py
+++ b/pydeepmerge/errors/errors.py
@@ -1,0 +1,20 @@
+'''
+A module with errors used for PyDeepMerge
+'''
+
+
+class DeepMergeError(Exception):
+    'An abstract base class for errors produced by this package'
+
+
+class ParserNotAvailableError(DeepMergeError):
+    '''
+    An error raised when a file does not have
+    an appropriate parser to read it currently installed
+    '''
+
+
+class FileTypeError(DeepMergeError):
+    '''
+    Error raised when file has no file type extension
+    '''

--- a/pydeepmerge/parsers/__init__.py
+++ b/pydeepmerge/parsers/__init__.py
@@ -1,0 +1,1 @@
+from pydeepmerge.parsers._loader import load_parsers  # noqa: F401

--- a/pydeepmerge/parsers/_loader.py
+++ b/pydeepmerge/parsers/_loader.py
@@ -1,0 +1,12 @@
+import pkg_resources
+import logging
+
+
+def load_parsers():
+    parsers = {}
+
+    for entry_point in pkg_resources.iter_entry_points('pydeepmerge.config_parsers'):
+        logging.debug(f'Found entry_point for {entry_point.name}')
+        parsers[entry_point.name] = entry_point.load()
+
+    return parsers

--- a/pydeepmerge/parsers/_loader.py
+++ b/pydeepmerge/parsers/_loader.py
@@ -6,7 +6,7 @@ def load_parsers():
     parsers = {}
 
     for entry_point in pkg_resources.iter_entry_points('pydeepmerge.config_parsers'):
-        logging.debug(f'Found entry_point for {entry_point.name}')
+        logging.debug('Found entry_point for %s', entry_point.name)
         parsers[entry_point.name] = entry_point.load()
 
     return parsers

--- a/pydeepmerge/parsers/json.py
+++ b/pydeepmerge/parsers/json.py
@@ -1,0 +1,7 @@
+import json
+
+
+def json_parser(filename):
+    with open(filename, 'r') as f:
+        data = json.load(f)
+    return data

--- a/pydeepmerge/types/__init__.py
+++ b/pydeepmerge/types/__init__.py
@@ -1,1 +1,4 @@
-from pydeepmerge.types.types import Key  # noqa: F401
+from pydeepmerge.types.types import (  # noqa: F401
+    Key,
+    MergeStrategy
+)

--- a/pydeepmerge/types/types.py
+++ b/pydeepmerge/types/types.py
@@ -1,5 +1,12 @@
 import enum
+from typing import (
+    Any,
+    Callable
+)
 
 
 class Key(enum.Enum):
     KeyNotFound = 1
+
+
+MergeStrategy = Callable[[Any, Any], Any]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,6 @@ description-file = README.md
 test =
     coveralls
     flake8
-    mock
     pytest
     pytest-cov
 dev = pre-commit
@@ -21,3 +20,8 @@ markers =
     unit: Marks a unit test
 testpaths = tests
 addopts = --cov=pydeepmerge --cov-report term-missing
+
+[coverage:run]
+omit =
+    pydeepmerge/errors/*
+    pydeepmerge/parsers/*

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,11 @@ setup(
     python_requires=">=3.5",
     packages=find_packages(),
     keywords='mapping dictionary library merge',
+    entry_points={
+        'pydeepmerge.config_parsers': [
+            '.json = pydeepmerge.parsers.json:json_parser',
+        ]
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/tests/unit/merge_configs_test.py
+++ b/tests/unit/merge_configs_test.py
@@ -1,0 +1,40 @@
+import pytest
+from unittest.mock import patch
+from pydeepmerge import merge_configs
+from pydeepmerge.errors import (
+    FileTypeError,
+    ParserNotAvailableError
+)
+
+
+@pytest.mark.unit
+@patch('pydeepmerge.parsers.json.json_parser')
+def test_merge_configs(mock_json_parser):
+    mock_json_parser.side_effect = [
+        {'foo': 'spam', 'egg': 'ham'},
+        {'foo': 'bar', 'baz': 'egg'}
+    ]
+
+    expected_return = {
+        'foo': 'bar',
+        'egg': 'ham',
+        'baz': 'egg'
+    }
+
+    assert merge_configs('foo.json', 'bar.json') == expected_return
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'exception_class,test_files',
+    [
+        (FileTypeError, ['foo', 'bar.json']),
+        (FileTypeError, ['foo.json', 'bar.yaml']),
+        (ParserNotAvailableError, ['foo.yaml', 'bar.yaml'])
+    ]
+)
+@patch('pydeepmerge.parsers.load_parsers')
+def test_merge_config_fail(mock_load_parser, exception_class, test_files):
+    mock_load_parser.return_value = {'.json': lambda x: x}
+    with pytest.raises(exception_class):
+        merge_configs(*test_files)

--- a/tests/unit/merge_configs_test.py
+++ b/tests/unit/merge_configs_test.py
@@ -8,20 +8,24 @@ from pydeepmerge.errors import (
 
 
 @pytest.mark.unit
-@patch('pydeepmerge.parsers.json.json_parser')
-def test_merge_configs(mock_json_parser):
-    mock_json_parser.side_effect = [
-        {'foo': 'spam', 'egg': 'ham'},
-        {'foo': 'bar', 'baz': 'egg'}
+@pytest.mark.parametrize(
+    'parser_returns,expected_result',
+    [
+        (
+            [{'foo': 'spam', 'egg': 'ham'}, {'bar': 'baz', 'spam': 'eggs'}],
+            {'foo': 'spam', 'egg': 'ham', 'bar': 'baz', 'spam': 'eggs'}
+        ),
+        (
+            [{'foo': 'spam', 'egg': 'ham'}, {'bar': 'baz', 'foo': 'ham'}],
+            {'foo': 'ham', 'egg': 'ham', 'bar': 'baz'}
+        ),
     ]
+)
+@patch('pydeepmerge.parsers.json.json_parser')
+def test_merge_configs(mock_json_parser, parser_returns, expected_result):
+    mock_json_parser.side_effect = parser_returns
 
-    expected_return = {
-        'foo': 'bar',
-        'egg': 'ham',
-        'baz': 'egg'
-    }
-
-    assert merge_configs('foo.json', 'bar.json') == expected_return
+    assert merge_configs('foo.json', 'bar.json') == expected_result
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Added function to merge configuration files directly.

The function accepts a sequence of file names and attempts to load them with the available parsers (with an option to specify more parsers in-line). The function can use any auto-loaded modules that are installed on the `pydeepmerge.config_parsers` entry_point (including from other packages), though at this time only `json` has a provided parser.